### PR TITLE
Update config.properties for v2 release shapes

### DIFF
--- a/validator/resources/healthri/config.properties
+++ b/validator/resources/healthri/config.properties
@@ -1,6 +1,32 @@
-validator.type = v1.0.0, development
+validator.type = v2.0.0, v1.0.0, development
 validator.owlImportErrors = warn
 validator.remoteArtefactLoadErrors = warn
+
+validator.typeLabel.v2.0.0 = v2.0.0-beta.1 Health-RI
+validator.shaclFile.v2.0.0.remote.0.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/Resource.ttl 
+validator.shaclFile.v2.0.0.remote.0.type = text/turtle
+validator.shaclFile.v2.0.0.remote.1.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/Catalog.ttl 
+validator.shaclFile.v2.0.0.remote.1.type = text/turtle
+validator.shaclFile.v2.0.0.remote.2.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl 
+validator.shaclFile.v2.0.0.remote.2.type = text/turtle
+validator.shaclFile.v2.0.0.remote.3.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/DatasetSeries.ttl
+validator.shaclFile.v2.0.0.remote.3.type = text/turtle
+validator.shaclFile.v2.0.0.remote.4.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/Distribution.ttl
+validator.shaclFile.v2.0.0.remote.4.type = text/turtle
+validator.shaclFile.v2.0.0.remote.5.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/DataService.ttl
+validator.shaclFile.v2.0.0.remote.5.type = text/turtle
+validator.shaclFile.v2.0.0.remote.6.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/Agent.ttl
+validator.shaclFile.v2.0.0.remote.6.type = text/turtle
+validator.shaclFile.v2.0.0.remote.7.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/Checksum.ttl
+validator.shaclFile.v2.0.0.remote.7.type = text/turtle
+validator.shaclFile.v2.0.0.remote.8.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/Kind.ttl
+validator.shaclFile.v2.0.0.remote.8.type = text/turtle
+validator.shaclFile.v2.0.0.remote.9.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/PeriodOfTime.ttl
+validator.shaclFile.v2.0.0.remote.9.type = text/turtle
+validator.shaclFile.v2.0.0.remote.10.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/Project.ttl
+validator.shaclFile.v2.0.0.remote.10.type = text/turtle
+validator.shaclFile.v2.0.0.remote.11.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/Study.ttl
+validator.shaclFile.v2.0.0.remote.11.type = text/turtle
 
 validator.typeLabel.v1.0.0 = v1.0.0 Health-RI core plateau 1
 validator.shaclFile.v1.0.0.remote.0.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v1.0.0/Formalisation(shacl)/Core/PiecesShape/Resource.ttl 
@@ -15,7 +41,6 @@ validator.shaclFile.v1.0.0.remote.4.url = https://raw.githubusercontent.com/Heal
 validator.shaclFile.v1.0.0.remote.4.type = text/turtle
 validator.shaclFile.v1.0.0.remote.5.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v1.0.0/Formalisation(shacl)/Core/PiecesShape/DataService.ttl
 validator.shaclFile.v1.0.0.remote.5.type = text/turtle
-
 
 validator.typeLabel.development = Development Health-RI core
 validator.shaclFile.development.remote.0.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/develop/Formalisation(shacl)/Core/PiecesShape/Resource.ttl 


### PR DESCRIPTION
Add the v2.0.0-beta.1 release to validator website

## Summary by Sourcery

Enhancements:
- Adds support for v2.0.0-beta.1 Health-RI metadata.