### PR TITLE
feat: update links to beta.2

### DIFF
--- a/validator/resources/healthri/config.properties
+++ b/validator/resources/healthri/config.properties
@@ -2,30 +2,30 @@ validator.type = v2.0.0, v1.0.0, development
 validator.owlImportErrors = warn
 validator.remoteArtefactLoadErrors = warn
 
-validator.typeLabel.v2.0.0 = v2.0.0-beta.1 Health-RI
-validator.shaclFile.v2.0.0.remote.0.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/Resource.ttl 
+validator.typeLabel.v2.0.0 = v2.0.0-beta.2 Health-RI
+validator.shaclFile.v2.0.0.remote.0.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.2/Formalisation(shacl)/Core/PiecesShape/Resource.ttl
 validator.shaclFile.v2.0.0.remote.0.type = text/turtle
-validator.shaclFile.v2.0.0.remote.1.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/Catalog.ttl 
+validator.shaclFile.v2.0.0.remote.1.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.2/Formalisation(shacl)/Core/PiecesShape/Catalog.ttl
 validator.shaclFile.v2.0.0.remote.1.type = text/turtle
-validator.shaclFile.v2.0.0.remote.2.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl 
+validator.shaclFile.v2.0.0.remote.2.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.2/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl
 validator.shaclFile.v2.0.0.remote.2.type = text/turtle
-validator.shaclFile.v2.0.0.remote.3.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/DatasetSeries.ttl
+validator.shaclFile.v2.0.0.remote.3.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.2/Formalisation(shacl)/Core/PiecesShape/DatasetSeries.ttl
 validator.shaclFile.v2.0.0.remote.3.type = text/turtle
-validator.shaclFile.v2.0.0.remote.4.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/Distribution.ttl
+validator.shaclFile.v2.0.0.remote.4.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.2/Formalisation(shacl)/Core/PiecesShape/Distribution.ttl
 validator.shaclFile.v2.0.0.remote.4.type = text/turtle
-validator.shaclFile.v2.0.0.remote.5.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/DataService.ttl
+validator.shaclFile.v2.0.0.remote.5.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.2/Formalisation(shacl)/Core/PiecesShape/DataService.ttl
 validator.shaclFile.v2.0.0.remote.5.type = text/turtle
-validator.shaclFile.v2.0.0.remote.6.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/Agent.ttl
+validator.shaclFile.v2.0.0.remote.6.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.2/Formalisation(shacl)/Core/PiecesShape/Agent.ttl
 validator.shaclFile.v2.0.0.remote.6.type = text/turtle
-validator.shaclFile.v2.0.0.remote.7.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/Checksum.ttl
+validator.shaclFile.v2.0.0.remote.7.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.2/Formalisation(shacl)/Core/PiecesShape/Checksum.ttl
 validator.shaclFile.v2.0.0.remote.7.type = text/turtle
-validator.shaclFile.v2.0.0.remote.8.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/Kind.ttl
+validator.shaclFile.v2.0.0.remote.8.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.2/Formalisation(shacl)/Core/PiecesShape/Kind.ttl
 validator.shaclFile.v2.0.0.remote.8.type = text/turtle
-validator.shaclFile.v2.0.0.remote.9.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/PeriodOfTime.ttl
+validator.shaclFile.v2.0.0.remote.9.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.2/Formalisation(shacl)/Core/PiecesShape/PeriodOfTime.ttl
 validator.shaclFile.v2.0.0.remote.9.type = text/turtle
-validator.shaclFile.v2.0.0.remote.10.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/Project.ttl
+validator.shaclFile.v2.0.0.remote.10.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.2/Formalisation(shacl)/Core/PiecesShape/Project.ttl
 validator.shaclFile.v2.0.0.remote.10.type = text/turtle
-validator.shaclFile.v2.0.0.remote.11.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.1/Formalisation(shacl)/Core/PiecesShape/Study.ttl
+validator.shaclFile.v2.0.0.remote.11.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.2/Formalisation(shacl)/Core/PiecesShape/Study.ttl
 validator.shaclFile.v2.0.0.remote.11.type = text/turtle
 
 validator.typeLabel.v1.0.0 = v1.0.0 Health-RI core plateau 1
@@ -59,5 +59,5 @@ validator.shaclFile.development.remote.5.type = text/turtle
 # validator.uploadTitle = FAIR Data Point RDF Validator
 # Minified HTML
 validator.uploadTitle = Health-RI RDF Validator
-validator.bannerHtml = <div><div style=display:table><div style=display:table-row><div style=display:table-cell><h1>Health-RI RDF Validator</h1></div></div><div style=display:table-row><div style=display:table-cell;padding-top:20px><p>This service allows you to validate RDF content against <a href=https://www.w3.org/TR/shacl/ >SHACL shapes</a>. The shapes conform to the <a href=https://github.com/Health-RI/health-ri-metadata/blob/v1.0.0/README.md>Health-RI core metadata</a> shapes, as produced in Plateau 1.<p>There might still be issues with these shapes. Please contact <a href=https://www.health-ri.nl>Health-RI</a> by opening an issue at our <a href=https://github.com/Health-RI/metadata-shacl-validation/issues/new>Github repository</a>.<p>As soon as any additional Health-RI petal shapes are finished, they will be added to this validator.</div></div></div><hr></div>
+validator.bannerHtml = <div><div style=display:table><div style=display:table-row><div style=display:table-cell><h1>Health-RI RDF Validator</h1></div></div><div style=display:table-row><div style=display:table-cell;padding-top:20px><p>This service allows you to validate RDF content against <a href=https://www.w3.org/TR/shacl/ >SHACL shapes</a>. The shapes conform to the <a href=https://github.com/Health-RI/health-ri-metadata/blob/v1.0.0/README.md>Health-RI core metadata</a> shapes, as produced in Plateau 2.<p>There might still be issues with these shapes. Please contact <a href=https://www.health-ri.nl>Health-RI</a> by opening an issue at our <a href=https://github.com/Health-RI/metadata-shacl-validation/issues/new>Github repository</a>.<p>As soon as any additional Health-RI petal shapes are finished, they will be added to this validator.</div></div></div><hr></div>
 


### PR DESCRIPTION
## Summary by Sourcery

Update validator configuration to reference Health-RI metadata version v2.0.0-beta.2

New Features:
- Update SHACL validation links to point to the latest beta.2 version of Health-RI metadata

Enhancements:
- Update configuration to reflect the progression from beta.1 to beta.2 in metadata version