### PR TITLE
feat: use v1.0.2 of the datamodel for the v1.0 validator

### DIFF
--- a/validator/resources/healthri/config.properties
+++ b/validator/resources/healthri/config.properties
@@ -6,18 +6,18 @@ validator.typeLabel.v2.0.0 = v2.0.0 Health-RI
 validator.shaclFile.v2.0.0.remote.0.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0/Formalisation(shacl)/Core/ValidationShape/HRI-Datamodel-shapes.ttl
 validator.shaclFile.v2.0.0.remote.0.type = text/turtle
 
-validator.typeLabel.v1.0.0 = v1.0.0 Health-RI core plateau 1
-validator.shaclFile.v1.0.0.remote.0.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v1.0.0/Formalisation(shacl)/Core/PiecesShape/Resource.ttl 
+validator.typeLabel.v1.0.0 = v1.0.2 Health-RI core plateau 1
+validator.shaclFile.v1.0.0.remote.0.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v1.0.2/Formalisation(shacl)/Core/PiecesShape/Resource.ttl 
 validator.shaclFile.v1.0.0.remote.0.type = text/turtle
-validator.shaclFile.v1.0.0.remote.1.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v1.0.0/Formalisation(shacl)/Core/PiecesShape/Catalog.ttl 
+validator.shaclFile.v1.0.0.remote.1.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v1.0.2/Formalisation(shacl)/Core/PiecesShape/Catalog.ttl 
 validator.shaclFile.v1.0.0.remote.1.type = text/turtle
-validator.shaclFile.v1.0.0.remote.2.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v1.0.0/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl 
+validator.shaclFile.v1.0.0.remote.2.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v1.0.2/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl 
 validator.shaclFile.v1.0.0.remote.2.type = text/turtle
-validator.shaclFile.v1.0.0.remote.3.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v1.0.0/Formalisation(shacl)/Core/PiecesShape/DatasetSeries.ttl
+validator.shaclFile.v1.0.0.remote.3.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v1.0.2/Formalisation(shacl)/Core/PiecesShape/DatasetSeries.ttl
 validator.shaclFile.v1.0.0.remote.3.type = text/turtle
-validator.shaclFile.v1.0.0.remote.4.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v1.0.0/Formalisation(shacl)/Core/PiecesShape/Distribution.ttl
+validator.shaclFile.v1.0.0.remote.4.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v1.0.2/Formalisation(shacl)/Core/PiecesShape/Distribution.ttl
 validator.shaclFile.v1.0.0.remote.4.type = text/turtle
-validator.shaclFile.v1.0.0.remote.5.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v1.0.0/Formalisation(shacl)/Core/PiecesShape/DataService.ttl
+validator.shaclFile.v1.0.0.remote.5.url = https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v1.0.2/Formalisation(shacl)/Core/PiecesShape/DataService.ttl
 validator.shaclFile.v1.0.0.remote.5.type = text/turtle
 
 validator.typeLabel.development = Development Health-RI core


### PR DESCRIPTION
Update to use v1.0.2 of the datamodel release.

## Summary by Sourcery

Update Health-RI v1.0 validator configuration to use datamodel release v1.0.2

Enhancements:
- Bump validator type label from v1.0.0 to v1.0.2
- Update all SHACL shape URLs to reference v1.0.2 of the Health-RI datamodel